### PR TITLE
(+) added error handling

### DIFF
--- a/nos/src/nos.s
+++ b/nos/src/nos.s
@@ -2603,7 +2603,10 @@ DO_AUTORUN:
         LDY     #>GETAUTORUNDCB2
         JSR     DOSIOV
 
-        jmp AUTORUN_NTRANS
+        ; Does the returned URL contain something?
+        lda AUTORUN_URL_LEN
+        bne AUTORUN_NTRANS
+        rts
 
 AUTORUN_APPKEY:
         .BYTE   $79, $DB        ; creator ID


### PR DESCRIPTION
#14 error handling
does not run the AUTORUN command when the URL returned as app key is empty

BUT: If the app key does not exist at all, the NOS Command Processor will hang until timeout (about 40s)

I didn't find a way to detect whether the "Open App Key" SIO call ($DC) succeeded. 

Code crashes at the "read app key" call (**nos.s**, line 2604)